### PR TITLE
[WIP] Queue events when offline

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -5,7 +5,17 @@ import { Elm } from './elm/Main.elm';
 const app = Elm.Main.init({
   node: document.getElementById('elm')
 });
-const socket = io();
+const socket = io({
+  autoConnect: false
+});
+
+socket.on('connect', function(){
+  console.log('socket connected');
+});
+
+socket.on('disconnect', function(){
+  console.log('socket disconnected');
+});
 
 socket.on('catchup', (catchupMessage) => {
   const { eventStream } = catchupMessage;
@@ -17,10 +27,36 @@ socket.on('event', (newEvent) => {
   app.ports.receiveEvents.send([newEvent]);
 })
 
+// let proposedEvents = [];
 app.ports.proposal.subscribe(function(event) {
   console.log("Sending proposal", event);
+  // proposedEvents = proposedEvents.concat([event]);
+  // console.log('proposedEvents before', proposedEvents);
   socket.emit('propose', event, (response) => {
     console.log("Received response", response);
     app.ports.proposalResponse.send(response);
+    // proposedEvents = proposedEvents.filter(proposedEvent => proposedEvent.clientEventId !== event.clientEventId);
+    // console.log('proposedEvents after', proposedEvents);
   });
 });
+
+socket.connect();
+
+window.RECONNECT_SOCKET = () => {
+  console.log('Reconnecting...');
+  // NOTE: Socket.io already does some queing automatically. I noticed that if I disconnected using the
+  // hacking mechanism commented out in the server index.js, that all I had to do was call socket.connect() again
+  // and it would complete sending the `propose`. However, I'm not sure if that works with all kinds of disconnects.
+  socket.connect();
+  // if (proposedEvents.length < 1) {
+  //   return;
+  // }
+  // const event = proposedEvents[0];
+  // console.log('Re-proposing event', event);
+  // socket.emit('propose', event, (response) => {
+  //   console.log("Received response", response);
+  //   app.ports.proposalResponse.send(response);
+  //   proposedEvents = proposedEvents.filter(proposedEvent => proposedEvent.clientEventId !== event.clientEventId);
+  //   console.log('proposedEvents after', proposedEvents);
+  // });
+}

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -41,6 +41,12 @@ io.on('connection', function(socket) {
       });
     }
   });
+
+  // (YK 2019/03/15): Here for testing disconnecting
+  // setTimeout(() => {
+  //   // This boolean trap is whether to close the connection: https://socket.io/docs/server-api/#socket-disconnect-close
+  //   socket.disconnect(true);
+  // }, 10 * 1000)
 });
 
 http.listen(3000, function() {


### PR DESCRIPTION
It looks like Socket.io already does some queing automatically.
I noticed that if I disconnected using the
hacky mechanism commented out in the server index.js,
that all I had to do was call socket.connect() again
and it would complete sending the `propose`.
However, I'm not sure if that works with all kinds of disconnects.

At the end of the day, this PR mostly creates hooks for being able to display whether we're online or offline, as well as a hook for reconnecting. This all needs to get wired up into Elm.

It also starts attempting to track the client's event id instead of having all
events have a clientId of zero. However, given that Socket.io already does its own queueing,
it looks like this may not have been necessary.

Lastly, when reconnecting, we're not doing anything yet on client or server to
filter catchup events to only ones we don't have.