### PR TITLE
Filter out remote events with ids lower than the `lastKnownEventId`

### DIFF
--- a/src/client/elm/CloudModel.elm
+++ b/src/client/elm/CloudModel.elm
@@ -261,14 +261,17 @@ buildCloudUpdate proposal sharedMsgEncoder coreUpdateFn updateLocalFn msg model 
             )
 
         RemoteOrigin events ->
-            ( { model
-                | sharedModelInfo =
-                    List.foldl (updateSharedRemoteModelOrigin coreUpdateFn)
-                        model.sharedModelInfo
-                        events
-              }
-            , Cmd.none
-            )
+            let newEvents =
+                List.filter (\event -> event.id > model.sharedModelInfo.latestKnownEventId) events
+            in
+                ( { model
+                    | sharedModelInfo =
+                        List.foldl (updateSharedRemoteModelOrigin coreUpdateFn)
+                            model.sharedModelInfo
+                            newEvents
+                }
+                , Cmd.none
+                )
 
         ControlMsg controlMsg ->
             let


### PR DESCRIPTION
Closes https://github.com/matthewsj/cloudmodel/issues/4

TODO: Add testing harness / infrastructure
- We still need to stub out a testing harness so that tests can be written easily

**Test Plan**
- Tested manually by locally forcing the catchup event to be sent into
  Elm repeatedly. Without this, duplicated TODOs appeared in the todo app.
  With this change, there were no duplicates
- Tested manually that new events still work